### PR TITLE
feat: Add immutable dependency injection with withDependencyInjection() method

### DIFF
--- a/src/Contracts/DependencyInjection/DependencyInjectionAwareInterface.php
+++ b/src/Contracts/DependencyInjection/DependencyInjectionAwareInterface.php
@@ -11,11 +11,30 @@ use Atournayre\Contracts\Exception\ThrowableInterface;
  *
  * Objects implementing this interface can have dependencies injected
  * and can access the dependency injection container.
+ *
+ * For immutable usage, prefer the withDependencyInjection() method over setDependencyInjection().
  */
 interface DependencyInjectionAwareInterface
 {
     /**
+     * Returns a new instance with the dependency injection container set.
+     *
+     * This method follows immutability principles by returning a new instance
+     * instead of modifying the current one.
+     *
+     * @param DependencyInjectionInterface $dependencyInjection The dependency injection container
+     *
+     * @return static A new instance with the dependency injection container set
+     */
+    public function withDependencyInjection(DependencyInjectionInterface $dependencyInjection): static;
+
+    /**
      * Sets the dependency injection container.
+     *
+     * This method modifies the current instance and is primarily used by the framework
+     * for scenarios like Doctrine PostLoad events where entity instances cannot be replaced.
+     *
+     * For application code that follows immutable patterns, prefer withDependencyInjection().
      *
      * @param DependencyInjectionInterface $dependencyInjection The dependency injection container
      */

--- a/src/DependencyInjection/DependencyInjectionPostLoad.php
+++ b/src/DependencyInjection/DependencyInjectionPostLoad.php
@@ -13,6 +13,11 @@ use Doctrine\ORM\Event\PostLoadEventArgs;
  *
  * This handler automatically injects dependencies into entities
  * that implement DependencyInjectionAwareInterface after they are loaded from the database.
+ *
+ * This handler uses setDependencyInjection() because Doctrine's PostLoad event works
+ * with existing entity instances that cannot be replaced with new instances.
+ * The immutable withDependencyInjection() method is not suitable for this use case
+ * as it returns a new instance.
  */
 final readonly class DependencyInjectionPostLoad implements PostLoadHandlerInterface
 {

--- a/src/Traits/DependencyInjectionTrait.php
+++ b/src/Traits/DependencyInjectionTrait.php
@@ -12,13 +12,38 @@ use Atournayre\Contracts\DependencyInjection\DependencyInjectionInterface;
  *
  * This trait provides an implementation of DependencyInjectionAwareInterface
  * that can be used by classes that need dependency injection capabilities.
+ *
+ * For immutable usage, prefer the withDependencyInjection() method over setDependencyInjection().
  */
 trait DependencyInjectionTrait
 {
     private ?DependencyInjectionInterface $dependencyInjection = null;
 
     /**
+     * Returns a new instance with the dependency injection container set.
+     *
+     * This method follows immutability principles by returning a new instance
+     * instead of modifying the current one.
+     *
+     * @param DependencyInjectionInterface $dependencyInjection The dependency injection container
+     *
+     * @return static A new instance with the dependency injection container set
+     */
+    public function withDependencyInjection(DependencyInjectionInterface $dependencyInjection): static
+    {
+        $clone = clone $this;
+        $clone->dependencyInjection = $dependencyInjection;
+
+        return $clone;
+    }
+
+    /**
      * Sets the dependency injection container.
+     *
+     * This method modifies the current instance and is primarily used by the framework
+     * for scenarios like Doctrine PostLoad events where entity instances cannot be replaced.
+     *
+     * For application code that follows immutable patterns, prefer withDependencyInjection().
      *
      * @param DependencyInjectionInterface $dependencyInjection The dependency injection container
      */

--- a/tests/Unit/DependencyInjection/DependencyInjectionTraitTest.php
+++ b/tests/Unit/DependencyInjection/DependencyInjectionTraitTest.php
@@ -38,6 +38,50 @@ final class DependencyInjectionTraitTest extends TestCase
         // Act
         $testObject->dependencyInjection();
     }
+
+    public function testWithDependencyInjectionReturnsNewInstance(): void
+    {
+        // Arrange
+        $dependencyInjection = $this->createMock(DependencyInjectionInterface::class);
+        $originalObject = new TestObjectWithDependencyInjection();
+
+        // Act
+        $newObject = $originalObject->withDependencyInjection($dependencyInjection);
+
+        // Assert
+        self::assertNotSame($originalObject, $newObject);
+        self::assertSame($dependencyInjection, $newObject->dependencyInjection());
+    }
+
+    public function testWithDependencyInjectionDoesNotModifyOriginal(): void
+    {
+        // Arrange
+        $dependencyInjection = $this->createMock(DependencyInjectionInterface::class);
+        $originalObject = new TestObjectWithDependencyInjection();
+
+        // Act
+        $newObject = $originalObject->withDependencyInjection($dependencyInjection);
+
+        // Assert
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Dependency injection has not been set');
+        $originalObject->dependencyInjection(); // Should still throw exception
+    }
+
+    public function testWithDependencyInjectionPreservesOtherProperties(): void
+    {
+        // Arrange
+        $dependencyInjection = $this->createMock(DependencyInjectionInterface::class);
+        $originalObject = new TestObjectWithDependencyInjection();
+        $originalObject->setTestProperty('test value');
+
+        // Act
+        $newObject = $originalObject->withDependencyInjection($dependencyInjection);
+
+        // Assert
+        self::assertSame('test value', $newObject->getTestProperty());
+        self::assertSame($dependencyInjection, $newObject->dependencyInjection());
+    }
 }
 
 /**
@@ -46,4 +90,22 @@ final class DependencyInjectionTraitTest extends TestCase
 final class TestObjectWithDependencyInjection implements DependencyInjectionAwareInterface
 {
     use DependencyInjectionTrait;
+
+    private string $testProperty = '';
+
+    /**
+     * @api
+     */
+    public function getTestProperty(): string
+    {
+        return $this->testProperty;
+    }
+
+    /**
+     * @api
+     */
+    public function setTestProperty(string $testProperty): void
+    {
+        $this->testProperty = $testProperty;
+    }
 }


### PR DESCRIPTION
This PR implements an immutable dependency injection system using the wither pattern, addressing all requirements from the previous issues while maintaining backward compatibility. Added withDependencyInjection() method, updated documentation, preserved PostLoad functionality, and added comprehensive tests.