### PR TITLE
feat: enhance SplFileInfo toLog() method / Issue #103

### DIFF
--- a/src/Wrapper/SplFileInfo.php
+++ b/src/Wrapper/SplFileInfo.php
@@ -40,8 +40,11 @@ final readonly class SplFileInfo implements LoggableInterface
     public function toLog(): array
     {
         return [
-            'pathname' => $this->pathname(),
+            'filename' => $this->filename()->toString(),
+            'extension' => $this->extension()->toString(),
             'size' => $this->size()->humanReadable(),
+            'relativePath' => $this->relativePath()->toString(),
+            'relativePathname' => $this->relativePathname()->toString(),
         ];
     }
 

--- a/tests/Unit/Wrapper/SplFileInfoTest.php
+++ b/tests/Unit/Wrapper/SplFileInfoTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atournayre\Tests\Wrapper;
+
+use Atournayre\Wrapper\SplFileInfo;
+use PHPUnit\Framework\TestCase;
+
+final class SplFileInfoTest extends TestCase
+{
+    public function testToLogReturnsArrayWithFilenameKey(): void
+    {
+        $file = SplFileInfo::of(__FILE__, '', '');
+        $result = $file->toLog();
+        self::assertArrayHasKey('filename', $result, 'toLog() must contain filename key');
+    }
+
+    public function testToLogReturnsArrayWithExtensionKey(): void
+    {
+        $file = SplFileInfo::of(__FILE__, '', '');
+        $result = $file->toLog();
+        self::assertArrayHasKey('extension', $result, 'toLog() must contain extension key');
+    }
+
+    public function testToLogReturnsArrayWithSizeKey(): void
+    {
+        $file = SplFileInfo::of(__FILE__, '', '');
+        $result = $file->toLog();
+        self::assertArrayHasKey('size', $result, 'toLog() must contain size key');
+    }
+
+    public function testToLogReturnsArrayWithRelativePathKey(): void
+    {
+        $file = SplFileInfo::of(__FILE__, '', '');
+        $result = $file->toLog();
+        self::assertArrayHasKey('relativePath', $result, 'toLog() must contain relativePath key');
+    }
+
+    public function testToLogReturnsArrayWithRelativePathnameKey(): void
+    {
+        $file = SplFileInfo::of(__FILE__, '', '');
+        $result = $file->toLog();
+        self::assertArrayHasKey('relativePathname', $result, 'toLog() must contain relativePathname key');
+    }
+
+    public function testToLogFilenameIsString(): void
+    {
+        $file = SplFileInfo::of(__FILE__, '', '');
+        $result = $file->toLog();
+        self::assertIsString($result['filename'], 'filename must be a string');
+    }
+
+    public function testToLogExtensionIsString(): void
+    {
+        $file = SplFileInfo::of(__FILE__, '', '');
+        $result = $file->toLog();
+        self::assertIsString($result['extension'], 'extension must be a string');
+    }
+
+    public function testToLogSizeIsString(): void
+    {
+        $file = SplFileInfo::of(__FILE__, '', '');
+        $result = $file->toLog();
+        self::assertIsString($result['size'], 'size must be a string');
+    }
+
+    public function testToLogRelativePathIsString(): void
+    {
+        $file = SplFileInfo::of(__FILE__, '', '');
+        $result = $file->toLog();
+        self::assertIsString($result['relativePath'], 'relativePath must be a string');
+    }
+
+    public function testToLogRelativePathnameIsString(): void
+    {
+        $file = SplFileInfo::of(__FILE__, '', '');
+        $result = $file->toLog();
+        self::assertIsString($result['relativePathname'], 'relativePathname must be a string');
+    }
+
+    public function testToLogFilenameMatchesActualFilename(): void
+    {
+        $file = SplFileInfo::of(__FILE__, '', '');
+        $result = $file->toLog();
+        self::assertEquals('SplFileInfoTest.php', $result['filename'], 'filename must match actual filename');
+    }
+
+    public function testToLogExtensionMatchesActualExtension(): void
+    {
+        $file = SplFileInfo::of(__FILE__, '', '');
+        $result = $file->toLog();
+        self::assertEquals('php', $result['extension'], 'extension must match php');
+    }
+
+    public function testToLogSizeContainsUnit(): void
+    {
+        $file = SplFileInfo::of(__FILE__, '', '');
+        $result = $file->toLog();
+        self::assertMatchesRegularExpression('/\d+(\.\d+)?\s*(B|KB|MB|GB)/', $result['size'], 'size must contain unit');
+    }
+}


### PR DESCRIPTION
## Summary

Enhance `SplFileInfo::toLog()` method to provide comprehensive file information for logging purposes.

Resolves #103

## Changes

- Enhanced `toLog()` method with 5 fields:
  - `filename`: File name as string
  - `extension`: File extension as string  
  - `size`: Human-readable size (B, KB, MB, GB)
  - `relativePath`: Relative path as string
  - `relativePathname`: Full relative pathname as string

- Added 13 comprehensive unit tests covering:
  - Array structure validation
  - Data type validation
  - Value accuracy validation

## Testing

- Unit tests: 13 tests added in `SplFileInfoTest.php`
- All tests follow Elegant Object principles (1 assertion per test)
- QA skipped (PHP 8.2.22 required, local 8.1.2)

## Checklist

- [x] Code follows project standards
- [x] Tests added/updated
- [ ] Documentation updated